### PR TITLE
closes #23

### DIFF
--- a/electionnight/management/commands/bake_elections.py
+++ b/electionnight/management/commands/bake_elections.py
@@ -1,9 +1,8 @@
 from django.core.management.base import BaseCommand
 from election.models import ElectionDay
+from electionnight.views import StatePage
 from geography.models import DivisionLevel
 from tqdm import tqdm
-
-from electionnight.views import StatePage
 
 
 # TODO: Clean this up and split methods out...

--- a/electionnight/views/base.py
+++ b/electionnight/views/base.py
@@ -2,8 +2,8 @@
 Base context for all pages, e.g., data needed to render navigation.
 """
 from datetime import datetime
-from django.views.generic import DetailView
 
+from django.views.generic import DetailView
 from electionnight.conf import settings
 
 from .mixins.statics.paths import StaticsPathsMixin
@@ -26,6 +26,7 @@ class BaseView(DetailView, StaticsPathsMixin, StaticsPublishingMixin):
         # different static path handling
         production = self.request.GET.get('env', 'dev') == 'prod'
         context['production'] = production
+        # When publishing, we use a subpath to determine relative paths
+        context['subpath'] = self.request.GET.get('subpath')
         context['now'] = datetime.now()
-
         return context

--- a/electionnight/views/states.py
+++ b/electionnight/views/states.py
@@ -7,12 +7,11 @@ URL PATTERNS:
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from election.models import ElectionDay
-from geography.models import Division, DivisionLevel
-
 from electionnight.conf import settings
 from electionnight.models import PageContent
 from electionnight.serializers import ElectionViewSerializer, StateSerializer
 from electionnight.utils.auth import secure
+from geography.models import Division, DivisionLevel
 
 from .base import BaseView
 
@@ -60,20 +59,29 @@ class StatePage(BaseView):
             **context,
             **self.get_paths_context(production=context['production']),
             **self.get_elections_context(context['division']),
-            **self.get_nav_links(),
+            **self.get_nav_links(subpath=context['subpath']),
         }
 
-    def get_nav_links(self):
+    def get_nav_links(self, subpath=None):
         state_level = DivisionLevel.objects.get(name=DivisionLevel.STATE)
         # All states except DC
         states = Division.objects.filter(
             level=state_level,
         ).exclude(code='11').order_by('label')
+        # Nav links should always refer to main state page. We can use subpath
+        # to determine how deep publish path is relative to state pages.
+        relative_prefix = ''
+        depth = subpath.lstrip('/').count('/')
+        for i in range(depth):
+            relative_prefix += '../'
         return {
             'nav': {
                 'states': [
                     {
-                        'link': '../{}/'.format(state.slug),
+                        'link': '../{0}{1}/'.format(
+                            relative_prefix,
+                            state.slug
+                        ),
                         'name': state.label,
                     } for state in states
                 ],
@@ -145,7 +153,6 @@ class StatePage(BaseView):
             'context': reverse(
                 'electionnight_api_state-election-detail',
                 args=[self.election_date, self.object.pk],
-                # request=self.request
             ),
             'geo_county': (
                 'https://s3.amazonaws.com/'


### PR DESCRIPTION
Adds subpath to view context. Uses it to determine depth of relative links, which we need to make sure that links to state pages always point to the canonical page.

For example, a link to the Texas state page needs to be rendered on these pages like this:

- `election-results/2018/arizona/`
  - Relative link: `../texas/`

- `election-results/2018/arizona/primary/`
  - Relative link: `../../texas/`